### PR TITLE
Convert from i32 -> i64 to support futhark64

### DIFF
--- a/lib/github.com/diku-dk/segmented/segmented.fut
+++ b/lib/github.com/diku-dk/segmented/segmented.fut
@@ -25,7 +25,7 @@ let segmented_reduce [n] 't (op: t -> t -> t) (ne: t)
   -- Find the segment ends.
   let segment_ends = rotate 1 flags
   -- Find the offset for each segment end.
-  let segment_end_offsets = segment_ends |> map i32.bool |> scan (+) 0
+  let segment_end_offsets = segment_ends |> map i64.bool |> scan (+) 0
   let num_segments = if n > 0 then last segment_end_offsets else 0
   -- Make room for the final result.  The specific value we write here
   -- does not matter; they will all be overwritten by the segment
@@ -41,11 +41,11 @@ let segmented_reduce [n] 't (op: t -> t -> t) (ne: t)
 -- the repetition array. As an example, replicated_iota [2,3,1]
 -- returns the array [0,0,1,1,1,2].
 
-let replicated_iota [n] (reps:[n]i32) : []i32 =
+let replicated_iota [n] (reps:[n]i64) : []i64 =
   let s1 = scan (+) 0 reps
   let s2 = map2 (\i x -> if i==0 then 0 else x)
                 (iota n) (rotate (-1) s1)
-  let tmp = reduce_by_index (replicate (reduce (+) 0 reps) 0) i32.max 0 s2 (iota n)
+  let tmp = reduce_by_index (replicate (reduce (+) 0 reps) 0) i64.max 0 s2 (iota n)
   let flags = map (>0) tmp
   in segmented_scan (+) 0 flags tmp
 
@@ -55,7 +55,7 @@ let replicated_iota [n] (reps:[n]i32) : []i32 =
 -- [false,false,false,true,false,false,false] returns the array
 -- [0,1,2,0,1,2,3].
 
-let segmented_iota [n] (flags:[n]bool) : [n]i32 =
+let segmented_iota [n] (flags:[n]bool) : [n]i64 =
   let iotas = segmented_scan (+) 0 flags (replicate n 1)
   in map (\x -> x-1) iotas
 
@@ -67,10 +67,10 @@ let segmented_iota [n] (flags:[n]bool) : [n]i32 =
 -- source. As an example, the expression expand (\x->x) (*) [2,3,1]
 -- returns the array [0,2,0,3,6,0].
 
-let expand 'a 'b (sz: a -> i32) (get: a -> i32 -> b) (arr:[]a) : []b =
+let expand 'a 'b (sz: a -> i64) (get: a -> i64 -> b) (arr:[]a) : []b =
   let szs = map sz arr
   let idxs = replicated_iota szs
-  let iotas = segmented_iota (map2 (!=) idxs (rotate (i32.negate 1) idxs))
+  let iotas = segmented_iota (map2 (!=) idxs (rotate (i64.negate 1) idxs))
   in map2 (\i j -> get arr[i] j) idxs iotas
 
 -- | Expansion function equivalent to performing a segmented reduction
@@ -81,11 +81,11 @@ let expand 'a 'b (sz: a -> i32) (get: a -> i32 -> b) (arr:[]a) : []b =
 -- if a segmented reduction (with an appropriate flags vector) is
 -- explicitly followed by a call to expand.
 
-let expand_reduce 'a 'b (sz: a -> i32) (get: a -> i32 -> b)
+let expand_reduce 'a 'b (sz: a -> i64) (get: a -> i64 -> b)
                         (op: b -> b -> b) (ne:b) (arr:[]a) : []b =
   let szs = map sz arr
   let idxs = replicated_iota szs
-  let flags = map2 (!=) idxs (rotate (i32.negate 1) idxs)
+  let flags = map2 (!=) idxs (rotate (i64.negate 1) idxs)
   let iotas = segmented_iota flags
   let vs = map2 (\i j -> get arr[i] j) idxs iotas
   in segmented_reduce op ne flags vs
@@ -94,7 +94,7 @@ let expand_reduce 'a 'b (sz: a -> i32) (get: a -> i32 -> b)
 -- that each element in the result array corresponds to expanding and
 -- reducing the corresponding element in the source array.
 
-let expand_outer_reduce 'a 'b [n] (sz: a -> i32) (get: a -> i32 -> b)
+let expand_outer_reduce 'a 'b [n] (sz: a -> i64) (get: a -> i64 -> b)
                                   (op: b -> b -> b) (ne: b)
                                   (arr: [n]a) : [n]b =
   let sz' x = let s = sz x

--- a/lib/github.com/diku-dk/segmented/segmented_tests.fut
+++ b/lib/github.com/diku-dk/segmented/segmented_tests.fut
@@ -33,7 +33,7 @@ entry test_segmented_reduce (flags: []bool) (as: []i32) =
 -- input { [0] } output { empty([0]i32) }
 -- input { [0,0] } output { empty([0]i32) }
 
-entry test_replicated_iota (repl:[]i32) : []i32 =
+entry test_replicated_iota (repl:[]i64) : []i64 =
   replicated_iota repl
 
 -- ==
@@ -44,7 +44,7 @@ entry test_replicated_iota (repl:[]i32) : []i32 =
 -- input { [true] } output { [0] }
 -- input { empty([0]bool) } output { empty([0]i32) }
 
-entry test_segmented_iota (flags:[]bool) : []i32 =
+entry test_segmented_iota (flags:[]bool) : []i64 =
   segmented_iota flags
 
 -- ==
@@ -52,7 +52,7 @@ entry test_segmented_iota (flags:[]bool) : []i32 =
 -- input { [2,3,1] }
 -- output { [0,2,0,3,6,0] }
 
-entry test_expand (arr:[]i32) : []i32 =
+entry test_expand (arr:[]i64) : []i64 =
   expand (\ x -> x) (\x i -> x*i) arr
 
 -- ==
@@ -60,7 +60,7 @@ entry test_expand (arr:[]i32) : []i32 =
 -- input { [2,0,3,1] }
 -- output { [2,9,0] }
 
-entry test_expand_reduce (arr:[]i32) : []i32 =
+entry test_expand_reduce (arr:[]i64) : []i64 =
   expand_reduce (\ x -> x) (\x i -> x*i) (+) 0 arr
 
 -- ==
@@ -68,5 +68,5 @@ entry test_expand_reduce (arr:[]i32) : []i32 =
 -- input { [2,0,3,1] }
 -- output { [2,0,9,0] }
 
-entry test_expand_outer_reduce (arr:[]i32) : []i32 =
+entry test_expand_outer_reduce (arr:[]i64) : []i64 =
   expand_outer_reduce (\ x -> x) (\x i -> x*i) (+) 0 arr

--- a/lib/github.com/diku-dk/segmented/segmented_tests.fut
+++ b/lib/github.com/diku-dk/segmented/segmented_tests.fut
@@ -4,34 +4,36 @@ import "segmented"
 
 -- ==
 -- entry: test_segmented_scan
--- input { [true,false,false,true,false,false,true,false,false,false] [1,2,3,4,5,6,7,8,9,10] }
--- output { [1,3,6,4,9,15,7,15,24,34] }
--- input { [true] [1] }
--- output { [1] }
--- input { empty([0]bool) empty([0]i32) }
--- output { empty([0]i32) }
+-- input { [true,false,false,true,false,false,true,false,false,false]
+--         [1i64,2i64,3i64,4i64,5i64,6i64,7i64,8i64,9i64,10i64] }
+-- output { [1i64,3i64,6i64,4i64,9i64,15i64,7i64,15i64,24i64,34i64] }
+-- input { [true] [1i64] }
+-- output { [1i64] }
+-- input { empty([0]bool) empty([0]i64) }
+-- output { empty([0]i64) }
 
-entry test_segmented_scan (flags: []bool) (as: []i32) =
+entry test_segmented_scan (flags: []bool) (as: []i64) =
   segmented_scan (+) 0 flags as
 
 -- ==
 -- entry: test_segmented_reduce
--- input { [true,false,false,true,false,false,true,false,false,false] [1,2,3,4,5,6,7,8,9,10] }
--- output { [6,15,34] }
--- input { [true] [1] }
--- output { [1] }
+-- input { [true,false,false,true,false,false,true,false,false,false]
+--         [1i64,2i64,3i64,4i64,5i64,6i64,7i64,8i64,9i64,10i64] }
+-- output { [6i64,15i64,34i64] }
+-- input { [true] [1i64] }
+-- output { [1i64] }
 
-entry test_segmented_reduce (flags: []bool) (as: []i32) =
+entry test_segmented_reduce (flags: []bool) (as: []i64) =
   segmented_reduce (+) 0 flags as
 
 -- ==
 -- entry: test_replicated_iota
--- input { [2,3,1] } output { [0,0,1,1,1,2] }
--- input { [3] } output { [0,0,0] }
--- input { [2,0,1] } output { [0,0,2] }
--- input { empty([0]i32) } output { empty([0]i32) }
--- input { [0] } output { empty([0]i32) }
--- input { [0,0] } output { empty([0]i32) }
+-- input { [2i64,3i64,1i64] } output { [0i64,0i64,1i64,1i64,1i64,2i64] }
+-- input { [3i64] } output { [0i64,0i64,0i64] }
+-- input { [2i64,0i64,1i64] } output { [0i64,0i64,2i64] }
+-- input { empty([0]i64) } output { empty([0]i64) }
+-- input { [0i64] } output { empty([0]i64) }
+-- input { [0i64,0i64] } output { empty([0]i64) }
 
 entry test_replicated_iota (repl:[]i64) : []i64 =
   replicated_iota repl
@@ -39,34 +41,34 @@ entry test_replicated_iota (repl:[]i64) : []i64 =
 -- ==
 -- entry: test_segmented_iota
 -- input { [false,false,false,true,false,false,false] }
--- output { [0,1,2,0,1,2,3] }
--- input { [false] } output { [0] }
--- input { [true] } output { [0] }
--- input { empty([0]bool) } output { empty([0]i32) }
+-- output { [0i64,1i64,2i64,0i64,1i64,2i64,3] }
+-- input { [false] } output { [0i64] }
+-- input { [true] } output { [0i64] }
+-- input { empty([0]bool) } output { empty([0]i64) }
 
 entry test_segmented_iota (flags:[]bool) : []i64 =
   segmented_iota flags
 
 -- ==
 -- entry: test_expand
--- input { [2,3,1] }
--- output { [0,2,0,3,6,0] }
+-- input { [2i64,3i64,1i64] }
+-- output { [0i64,2i64,0i64,3i64,6i64,0i64] }
 
 entry test_expand (arr:[]i64) : []i64 =
   expand (\ x -> x) (\x i -> x*i) arr
 
 -- ==
 -- entry: test_expand_reduce
--- input { [2,0,3,1] }
--- output { [2,9,0] }
+-- input { [2i64,0i64,3i64,1i64] }
+-- output { [2i64,9i64,0i64] }
 
 entry test_expand_reduce (arr:[]i64) : []i64 =
   expand_reduce (\ x -> x) (\x i -> x*i) (+) 0 arr
 
 -- ==
 -- entry: test_expand_outer_reduce
--- input { [2,0,3,1] }
--- output { [2,0,9,0] }
+-- input { [2i64,0i64,3i64,1i64] }
+-- output { [2i64,0i64,9i64,0i64] }
 
 entry test_expand_outer_reduce (arr:[]i64) : []i64 =
   expand_outer_reduce (\ x -> x) (\x i -> x*i) (+) 0 arr


### PR DESCRIPTION
This is a rather naive approach, that just replaces every reference to i32 with i64.

Would you prefer to keep the interface 32-bit, or is this okay?