### PR TITLE
Uniqueness annotations on return types

### DIFF
--- a/lib/github.com/diku-dk/segmented/segmented.fut
+++ b/lib/github.com/diku-dk/segmented/segmented.fut
@@ -5,7 +5,7 @@
 -- segments of ``as`` specified by the ``flags`` array, where `true`
 -- starts a segment and `false` continues a segment.
 def segmented_scan [n] 't (op: t -> t -> t) (ne: t)
-                          (flags: [n]bool) (as: [n]t): [n]t =
+                          (flags: [n]bool) (as: [n]t): *[n]t =
   (unzip (scan (\(x_flag,x) (y_flag,y) ->
                 (x_flag || y_flag,
                  if y_flag then y else x `op` y))
@@ -41,7 +41,7 @@ def segmented_reduce [n] 't (op: t -> t -> t) (ne: t)
 -- the repetition array. As an example, replicated_iota [2,3,1]
 -- returns the array [0,0,1,1,1,2].
 
-def replicated_iota [n] (reps:[n]i64) : []i64 =
+def replicated_iota [n] (reps:[n]i64) : *[]i64 =
   let offsets = scan (+) 0 reps
   in hist (+) 0 (i64.sum reps) offsets (replicate n 1)
   |> scan (+) 0 
@@ -52,7 +52,7 @@ def replicated_iota [n] (reps:[n]i64) : []i64 =
 -- [false,false,false,true,false,false,false] returns the array
 -- [0,1,2,0,1,2,3].
 
-def segmented_iota [n] (flags:[n]bool) : [n]i64 =
+def segmented_iota [n] (flags:[n]bool) : *[n]i64 =
   let iotas = segmented_scan (+) 0 flags (replicate n 1)
   in map (\x -> x-1) iotas
 
@@ -62,7 +62,7 @@ def segmented_iota [n] (flags:[n]bool) : [n]i64 =
 -- in the replicated iota. As an example repl_segm_iota [2,3,1]
 -- returns the arrays [0,0,1,1,1,2] and [0,1,0,1,2,0].
 
-def repl_segm_iota [n] (reps:[n]i64) : ([]i64, []i64) =
+def repl_segm_iota [n] (reps:[n]i64) : (*[]i64, *[]i64) =
     if n == 0 then ([], []) else
     let offsets = scan (+) 0 reps
     let start_idx = map2 (-) offsets reps
@@ -80,7 +80,7 @@ def repl_segm_iota [n] (reps:[n]i64) : ([]i64, []i64) =
 -- source. As an example, the expression expand (\x->x) (*) [2,3,1]
 -- returns the array [0,2,0,3,6,0].
 
-def expand 'a 'b (sz: a -> i64) (get: a -> i64 -> b) (arr:[]a) : []b =
+def expand 'a 'b (sz: a -> i64) (get: a -> i64 -> b) (arr:[]a) : *[]b =
   let szs = map sz arr
   let (idxs, iotas) = repl_segm_iota szs
   in map2 (\i j -> get arr[i] j) idxs iotas
@@ -94,7 +94,7 @@ def expand 'a 'b (sz: a -> i64) (get: a -> i64 -> b) (arr:[]a) : []b =
 -- explicitly followed by a call to expand.
 
 def expand_reduce 'a 'b (sz: a -> i64) (get: a -> i64 -> b)
-                        (op: b -> b -> b) (ne:b) (arr:[]a) : []b =
+                        (op: b -> b -> b) (ne:b) (arr:[]a) : *[]b =
   let szs = map sz arr
   let idxs = replicated_iota szs
   let flags = map2 (!=) idxs (rotate (-1) idxs)
@@ -108,7 +108,7 @@ def expand_reduce 'a 'b (sz: a -> i64) (get: a -> i64 -> b)
 
 def expand_outer_reduce 'a 'b [n] (sz: a -> i64) (get: a -> i64 -> b)
                                   (op: b -> b -> b) (ne: b)
-                                  (arr: [n]a) : [n]b =
+                                  (arr: [n]a) : *[n]b =
   let sz' x = let s = sz x
               in if s == 0 then 1 else s
   let get' x i = if sz x == 0 then ne else get x i


### PR DESCRIPTION
I noticed a bunch of analogous functions (`map`, `hist`, `scan`, `scatter`, `tabulate`, and so on) in the prelude have uniqueness annotations on their return types. I heard this might be beneficial to performance in some cases. I have not benchmarked this change to see if it actually impacts the performance of anything, but all the tests pass.